### PR TITLE
#MLOPS-101-102 Added an endpoint to delete multiple iterations and an endpoint for renaming an iteration

### DIFF
--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -14,11 +14,11 @@ class Iteration(BaseModel):
     metrics: Optional[dict] = Field(default=None, description="Iteration metrics")
     parameters: Optional[dict] = Field(default=None, description="Iteration parameters")
     path_to_model: Optional[str] = Field(default='', description="Path to model")
-    model_name: Optional[str] = Field(default=None, description="Model name")
+    model_name: Optional[str] = Field(default=None, description="Model name", min_length=1, max_length=100)
 
     @validator('path_to_model')
     def path_to_model_exists(cls, path):
-        if path is None or path == '':
+        if not path:
             return path
         path = r'{}'.format(path)
         if os.path.isfile(path):
@@ -60,3 +60,13 @@ class Iteration(BaseModel):
             }
         }
 
+
+class UpdateIteration(Iteration):
+    iteration_name: Optional[str]
+
+    class Config:
+        schema_extra = {
+                    "example": {
+                        "iteration_name": "New name"
+                    }
+                }

--- a/back-end/app/routers/iteration.py
+++ b/back-end/app/routers/iteration.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, status
 from beanie import PydanticObjectId
 from typing import List
 
-from app.models.iteration import Iteration
+from app.models.iteration import Iteration, UpdateIteration
 from app.models.project import Project
 from app.routers.exceptions.experiment import experiment_not_found_exception
 from app.routers.exceptions.project import project_not_found_exception
@@ -17,6 +17,13 @@ iteration_router = APIRouter()
 async def get_iterations(project_id: PydanticObjectId, experiment_id: PydanticObjectId) -> List[Iteration]:
     """
     Retrieve all iteration for selected experiment.
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+
+    Returns:
+        List[Iteration]: List of iterations
     """
     project = await Project.get(project_id)
     if not project:
@@ -33,13 +40,18 @@ async def get_iterations(project_id: PydanticObjectId, experiment_id: PydanticOb
 
 
 @iteration_router.get("/{id}", response_model=Iteration, status_code=status.HTTP_200_OK)
-async def get_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, id: PydanticObjectId) -> Iteration:
+async def get_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, id: PydanticObjectId) -> \
+        Iteration:
     """
     Retrieve iteration by id.
-    :param project_id:
-    :param experiment_id:
-    :param id:
-    :return: Iteration
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+        id (PydanticObjectId): Iteration id
+
+    Returns:
+        Iteration: Iteration
     """
 
     project = await Project.get(project_id)
@@ -58,13 +70,18 @@ async def get_iteration(project_id: PydanticObjectId, experiment_id: PydanticObj
 
 
 @iteration_router.get("/name/{name}", response_model=List[Iteration], status_code=status.HTTP_200_OK)
-async def get_iterations_by_name(project_id: PydanticObjectId, experiment_id: PydanticObjectId, name: str) -> List[Iteration]:
+async def get_iterations_by_name(project_id: PydanticObjectId, experiment_id: PydanticObjectId, name: str) -> \
+        List[Iteration]:
     """
     Retrieve all iterations by name.
-    :param project_id:
-    :param experiment_id:
-    :param name:
-    :return: List[Iteration]
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+        name (str): Iteration name
+
+    Returns:
+        List[Iteration]: List of iterations with selected name
     """
 
     project = await Project.get(project_id)
@@ -84,13 +101,18 @@ async def get_iterations_by_name(project_id: PydanticObjectId, experiment_id: Py
 
 
 @iteration_router.post("/", response_model=Iteration, status_code=status.HTTP_201_CREATED)
-async def add_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, iteration: Iteration) -> Iteration:
+async def add_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, iteration: Iteration) -> \
+        Iteration:
     """
     Add new iteration to experiment.
-    :param project_id:
-    :param experiment_id:
-    :param iteration:
-    :return: Iteration
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+        iteration (Iteration): Iteration
+
+    Returns:
+        Iteration: Iteration added to experiment
     """
 
     project = await Project.get(project_id)
@@ -109,14 +131,53 @@ async def add_iteration(project_id: PydanticObjectId, experiment_id: PydanticObj
     return iteration
 
 
+@iteration_router.put("/{id}", response_model=Iteration, status_code=status.HTTP_200_OK)
+async def update_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, id: PydanticObjectId,
+                           updated_iteration: UpdateIteration) -> Iteration:
+    """
+    Update iteration by id.
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+        id (PydanticObjectId): Iteration id
+        updated_iteration (UpdateIteration): Updated iteration
+
+    Returns:
+        Iteration: Updated iteration
+    """
+
+    project = await Project.get(project_id)
+    if not project:
+        raise project_not_found_exception()
+
+    experiment = next((exp for exp in project.experiments if exp.id == experiment_id), None)
+    if not experiment:
+        raise experiment_not_found_exception()
+
+    iteration = next((iter for iter in experiment.iterations if iter.id == id), None)
+    if not iteration:
+        raise iteration_not_found_exception()
+
+    iteration.iteration_name = updated_iteration.iteration_name or iteration.iteration_name
+
+    await project.save()
+
+    return iteration
+
+
 @iteration_router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, id: PydanticObjectId):
+async def delete_iteration(project_id: PydanticObjectId, experiment_id: PydanticObjectId, id: PydanticObjectId) -> None:
     """
     Delete iteration by id.
-    :param project_id:
-    :param experiment_id:
-    :param id:
-    :return: None
+
+    Args:
+        project_id (PydanticObjectId): Project id
+        experiment_id (PydanticObjectId): Experiment id
+        id (PydanticObjectId): Iteration id
+
+    Returns:
+        None: None
     """
 
     project = await Project.get(project_id)

--- a/back-end/app/tests/routers/test_experiment.py
+++ b/back-end/app/tests/routers/test_experiment.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 async def test_empty_get_experiments(client: AsyncClient):
     """
     Test get all experiments when there are no experiments
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     # create a new project
     await drop_database()
@@ -26,13 +32,19 @@ async def test_empty_get_experiments(client: AsyncClient):
     response = await client.get(f"/projects/{project_id}/experiments/")
 
     assert response.status_code == 200
-    assert(len(response.json()) == 0)
+    assert (len(response.json()) == 0)
 
 
 @pytest.mark.asyncio
 async def test_add_experiment(client: AsyncClient):
     """
     Test add experiment
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project = {
         "title": "Test project 2"
@@ -54,6 +66,12 @@ async def test_add_experiment(client: AsyncClient):
 async def test_get_experiments(client: AsyncClient):
     """
     Test get all experiments if there are experiments
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
     response = await client.get(f"/projects/title/{project_title}")
@@ -61,13 +79,19 @@ async def test_get_experiments(client: AsyncClient):
 
     response = await client.get(f"/projects/{project_id}/experiments/")
     assert response.status_code == 200
-    assert(len(response.json()) >= 1)
+    assert (len(response.json()) >= 1)
 
 
 @pytest.mark.asyncio
 async def test_get_experiment(client: AsyncClient):
     """
     Test get experiment by id
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
 
@@ -98,6 +122,12 @@ async def test_get_experiment(client: AsyncClient):
 async def test_change_experiment_name(client: AsyncClient):
     """
     Test change experiment name
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
 
@@ -118,10 +148,17 @@ async def test_change_experiment_name(client: AsyncClient):
     assert response.status_code == 200
     assert response.json()['name'] == new_name
 
+
 @pytest.mark.asyncio
 async def test_change_experiment_description(client: AsyncClient):
     """
     Test change experiment description
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
 
@@ -137,7 +174,8 @@ async def test_change_experiment_description(client: AsyncClient):
     experiment_id = response.json()["id"]
 
     description = "I have changed the description"
-    response = await client.put(f"/projects/{project_id}/experiments/{experiment_id}", json={"description": description})
+    response = await client.put(f"/projects/{project_id}/experiments/{experiment_id}",
+                                json={"description": description})
 
     assert response.status_code == 200
     assert response.json()['description'] == description
@@ -147,6 +185,12 @@ async def test_change_experiment_description(client: AsyncClient):
 async def test_get_experiment_by_name(client: AsyncClient):
     """
     Test get experiment by name
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
 
@@ -166,6 +210,12 @@ async def test_get_experiment_by_name(client: AsyncClient):
 async def test_delete_experiment(client: AsyncClient):
     """
     Test delete experiment
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
     project_title = "Test project 2"
 
@@ -173,7 +223,7 @@ async def test_delete_experiment(client: AsyncClient):
     project_id = response.json()["_id"]
 
     experiment = {
-        "name": "Test experiment 3",
+        "name": "Test experiment 3"
     }
     response = await client.post(f"/projects/{project_id}/experiments/", json=experiment)
     # Log the response and status code
@@ -184,4 +234,72 @@ async def test_delete_experiment(client: AsyncClient):
     experiment_id = response.json()["id"]
 
     response = await client.delete(f"/projects/{project_id}/experiments/{experiment_id}")
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_iterations(client: AsyncClient):
+    """
+    Test delete iterations.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+
+    project = {
+        "title": "Test project to delete few iterations",
+        "description": "Test project description"
+    }
+    response = await client.post("/projects/", json=project)
+    project_id = response.json()["_id"]
+
+    experiment_dict = {}
+
+    experiment_1 = {
+        "name": "Test experiment 1",
+        "description": "Test experiment description"
+    }
+
+    experiment_2 = {
+        "name": "Test experiment 2",
+        "description": "Test experiment description"
+    }
+
+    response = await client.post(f"/projects/{project_id}/experiments/", json=experiment_1)
+    experiment_1_id = response.json()["id"]
+    experiment_dict[experiment_1_id] = []
+
+    response = await client.post(f"/projects/{project_id}/experiments/", json=experiment_2)
+    experiment_2_id = response.json()["id"]
+    experiment_dict[experiment_2_id] = []
+
+    iteration_1 = {
+        "iteration_name": "Test iteration 1",
+        "description": "Test iteration description",
+        "metrics": {"accuracy": 0.9, "precision": 0.8, "recall": 0.7, "f1": 0.6},
+        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.001}
+    }
+
+    iteration_2 = {
+        "iteration_name": "Test iteration 2",
+        "description": "Test iteration description",
+        "metrics": {"accuracy": 0.9, "precision": 0.8, "recall": 0.7, "f1": 0.6},
+        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.001}
+    }
+
+    response = await client.post(f"/projects/{project_id}/experiments/{experiment_1_id}/iterations/",
+                                 json=iteration_1)
+    iteration_1_id = response.json()["id"]
+    experiment_dict[experiment_1_id].append(iteration_1_id)
+
+    response = await client.post(f"/projects/{project_id}/experiments/{experiment_2_id}/iterations/",
+                                 json=iteration_2)
+    iteration_2_id = response.json()["id"]
+    experiment_dict[experiment_2_id].append(iteration_2_id)
+
+    response = await client.post(f"/projects/{project_id}/experiments/delete_iterations", json=experiment_dict)
+
     assert response.status_code == 204

--- a/back-end/app/tests/routers/test_iteration.py
+++ b/back-end/app/tests/routers/test_iteration.py
@@ -14,8 +14,12 @@ logger = logging.getLogger(__name__)
 async def test_empty_get_iterations(client: AsyncClient):
     """
     Test get all iterations when there are no iterations.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     await drop_database()
@@ -44,8 +48,12 @@ async def test_empty_get_iterations(client: AsyncClient):
 async def test_add_iteration(client: AsyncClient):
     """
     Test add iteration without path_to_model.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     project_title = "Test project"
@@ -74,8 +82,12 @@ async def test_add_iteration(client: AsyncClient):
 async def test_add_iteration2(client: AsyncClient):
     """
     Test add iteration with path_to_model.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     project_title = "Test project"
@@ -107,8 +119,12 @@ async def test_add_iteration2(client: AsyncClient):
 async def test_get_iterations(client: AsyncClient):
     """
     Test get all iterations if there are iterations.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     project_title = "Test project"
@@ -130,8 +146,12 @@ async def test_get_iterations(client: AsyncClient):
 async def test_get_iteration_or_iterations_by_name(client: AsyncClient):
     """
     Test get iteration or iterations by name.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     project_title = "Test project"
@@ -151,11 +171,55 @@ async def test_get_iteration_or_iterations_by_name(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_change_iteration_name(client: AsyncClient):
+    """
+    Test change iteration name.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+
+    project_title = "Test project"
+
+    response = await client.get(f"/projects/title/{project_title}")
+    project_id = response.json()["_id"]
+
+    experiment_name = "Test experiment"
+    response = await client.get(f"/projects/{project_id}/experiments/name/{experiment_name}")
+    experiment_id = response.json()["id"]
+
+    iteration = {
+        "iteration_name": "Test iteration to change",
+        "description": "Test iteration description to change",
+        "metrics": {"accuracy": 0.8, "precision": 0.7, "recall": 0.9, "f1": 0.75},
+        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.0001},
+        "model_name": "Test model name to change"
+    }
+
+    response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
+    iteration_id = response.json()["id"]
+
+    new_name = "Changed iteration name"
+    response = await client.put(f"/projects/{project_id}/experiments/{experiment_id}/iterations/{iteration_id}",
+                                json={"iteration_name": new_name})
+
+    assert response.status_code == 200
+    assert response.json()['iteration_name'] == new_name
+
+
+@pytest.mark.asyncio
 async def test_delete_iteration_by_id(client: AsyncClient):
     """
     Test delete iteration by id.
-    :param client:
-    :return:
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
     """
 
     project_title = "Test project"


### PR DESCRIPTION
In back-end/app/routers/experiment.py has been added an endpoint to delete multiple iterations from multiple experiments for the same project. This endpoint has been added as POST, since in POST is possibility to send json with data to delete.But it is used for removal. 
An endpoint for renaming an iteration has also been added. All new endpoints have been tested succesfully.
