### PR TITLE
#MLOPS-90-91-92 Previous sprint back-end refactors

### DIFF
--- a/back-end/app/models/experiment.py
+++ b/back-end/app/models/experiment.py
@@ -8,7 +8,7 @@ from app.models.iteration import Iteration
 class Experiment(BaseModel):
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     name: str = Field(..., description="Experiment title", min_length=1, max_length=40)
-    description: Optional[str] = Field(default=None, description="Experiment description", max_length=150)
+    description: Optional[str] = Field(default="", description="Experiment description", max_length=150)
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: Optional[datetime] = Field(default_factory=datetime.now)
     iterations: List[Iteration] = []

--- a/back-end/app/models/project.py
+++ b/back-end/app/models/project.py
@@ -9,7 +9,7 @@ from app.models.experiment import Experiment
 
 class Project(Document):
     title: str = Field(description="Project title", min_length=1, max_length=40)
-    description: Optional[str] = Field(default=None, description="Project description", max_length=150)
+    description: Optional[str] = Field(default="", description="Project description", max_length=150)
     status: str = Field(default='not_started', description="Project status")
     archived: bool = Field(default=False, description="Project status")
     created_at: datetime = Field(default_factory=datetime.now)

--- a/back-end/app/routers/project.py
+++ b/back-end/app/routers/project.py
@@ -8,7 +8,6 @@ from app.models.project import Project, UpdateProject
 from app.routers.exceptions.project import (
     project_not_found_exception,
     project_title_not_unique_exception,
-    project_has_remaining_experiments_exception
 )
 
 router = APIRouter()
@@ -73,10 +72,6 @@ async def delete_project(id: PydanticObjectId):
     project = await Project.get(id)
     if not project:
         raise project_not_found_exception()
-
-    # let's not allow deleting if project has remaining experiments
-    if project.experiments:
-        raise project_has_remaining_experiments_exception()
 
     await project.delete()
     return None

--- a/back-end/app/tests/routers/test_project.py
+++ b/back-end/app/tests/routers/test_project.py
@@ -6,6 +6,15 @@ from app.database.init_mongo_db import drop_database
 
 @pytest.mark.asyncio
 async def test_empty_get_projects(client: AsyncClient):
+    """
+    Test get all projects when there are no projects.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     await drop_database()
     response = await client.get("/projects/")
     assert response.status_code == 200
@@ -14,16 +23,35 @@ async def test_empty_get_projects(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_create_project(client: AsyncClient):
+    """
+    Test create project.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project = {
         "title": "Test project"
     }
     response = await client.post("/projects/", json=project)
     assert response.status_code == 201
     assert response.json()["title"] == project["title"]
+    assert response.json()["description"] == ""
 
 
 @pytest.mark.asyncio
 async def test_title_unique(client: AsyncClient):
+    """
+    Test create project with title that already exists.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project = {
         "title": "Test project"
     }
@@ -34,6 +62,15 @@ async def test_title_unique(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_get_project_by_id(client: AsyncClient):
+    """
+    Test get project by id.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project = {
         "title": "Test project 2"
     }
@@ -47,6 +84,15 @@ async def test_get_project_by_id(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_get_project_by_name(client: AsyncClient):
+    """
+    Test get project by name.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project_title = "Test project 2"
     response = await client.get(f"/projects/title/{project_title}")
     assert response.status_code == 200
@@ -55,6 +101,15 @@ async def test_get_project_by_name(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_change_project_title(client: AsyncClient):
+    """
+    Test change project title.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project_title = "Test project 2"
     new_title = "New title"
     response = await client.get(f"/projects/title/{project_title}")
@@ -66,6 +121,15 @@ async def test_change_project_title(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_change_project_status(client: AsyncClient):
+    """
+    Test change project status.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project_title = "New title"
     new_status = "wrong status"
     response = await client.get(f"/projects/title/{project_title}")
@@ -82,9 +146,52 @@ async def test_change_project_status(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_delete_project(client: AsyncClient):
+    """
+    Test delete project if there are no experiments.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
     project_title = "New title"
     response = await client.get(f"/projects/title/{project_title}")
     project_id = response.json()["_id"]
+    response = await client.delete(f"/projects/{project_id}")
+    assert response.status_code == 204
+
+
+async def test_delete_project_with_experiments(client: AsyncClient):
+    """
+    Test delete project if there are experiments inside.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    project = {
+        "title": "Project with experiments",
+        "description": "Description not empty"
+    }
+    response = await client.post("/projects/", json=project)
+    project_id = response.json()["_id"]
+    assert response.status_code == 201
+    assert response.json()["title"] == project["title"]
+    assert response.json()["description"] == project["description"]
+
+    experiment = {
+        "name": "Test experiment"
+    }
+    response = await client.post(f"/projects/{project_id}/experiments/", json=experiment)
+    assert response.status_code == 201
+
+    response = await client.get(f"/projects/{project_id}")
+    assert response.status_code == 200
+    assert len(response.json()["experiments"]) == 1
+
     response = await client.delete(f"/projects/{project_id}")
     assert response.status_code == 204
 


### PR DESCRIPTION
Some refactors in terms of previous sprint that includes:
- allowing to delete non-empty projects
-  default description value for experiments and projects is now empty string instead of None
- unit testing/front-end testing above features