### PR TITLE
#MLOPS-151 Fixed project update endpoint and added docstrings in models

### DIFF
--- a/back-end/app/models/dataset.py
+++ b/back-end/app/models/dataset.py
@@ -13,22 +13,14 @@ class Dataset(Document):
 
     Attributes:
     -----------
-    dataset_name: str
-        Dataset name
-    path_to_dataset: str
-        Path to dataset
-    dataset_description: str
-        Dataset description
-    dataset_problem_type: str
-        Dataset problem type
-    created_at: datetime
-        Date and time of dataset creation
-    updated_at: datetime
-        Date and time of dataset update
-    version: str
-        Dataset version
-    linked_iterations: dict
-        Linked iterations (key: iteration id, value: (project id, experiment id)
+    - **id** dataset_name (str): Dataset name
+    - **path_to_dataset** (str): Path to dataset
+    - **dataset_description** (str): Dataset description
+    - **dataset_problem_type** (str): Dataset problem type
+    - **created_at** (datetime): Date and time of dataset creation
+    - **updated_at** (datetime): Date and time of dataset update
+    - **version** (str): Dataset version
+    - **linked_iterations** (Dict): Linked iterations (key - iteration id, value - (project_id, experiment_id)
     """
 
     dataset_name: str = Field(..., description="Dataset name", min_length=1, max_length=40)
@@ -95,6 +87,18 @@ class Dataset(Document):
 
 
 class UpdateDataset(Dataset):
+    """
+    Dataset model for update
+
+    Attributes:
+    - **dataset_name (str)**: Dataset name
+    - **path_to_dataset (str)**: Path to dataset
+    - **dataset_description (str)**: Dataset description
+    - **dataset_problem_type (str)**: Dataset problem type
+    - **version (str)**: Dataset version
+    - **updated_at (datetime)**: Date and time of dataset update
+    """
+
     dataset_name: Optional[str]
     path_to_dataset: Optional[Union[str, HttpUrl, Path]]
     dataset_description: Optional[str]

--- a/back-end/app/models/experiment.py
+++ b/back-end/app/models/experiment.py
@@ -6,6 +6,19 @@ from app.models.iteration import Iteration
 
 
 class Experiment(BaseModel):
+    """
+    Experiment model.
+
+    Attributes:
+    - **id (PydanticObjectId)**: Experiment ID.
+    - **project_id (PydanticObjectId)**: Project ID.
+    - **name (str)**: Experiment title.
+    - **description (Optional[str])**: Experiment description.
+    - **created_at (datetime)**: Experiment creation date.
+    - **updated_at (Optional[datetime])**: Experiment last update date.
+    - **iterations (List[Iteration])**: Experiment iterations.
+    """
+
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     project_id: PydanticObjectId = Field(default=None, alias="project_id")
     name: str = Field(..., description="Experiment title", min_length=1, max_length=40)
@@ -41,6 +54,15 @@ class Experiment(BaseModel):
 
 
 class UpdateExperiment(Experiment):
+    """
+    Update experiment model.
+
+    Attributes:
+    - **name (Optional[str])**: Experiment title.
+    - **description (Optional[str])**: Experiment description.
+    - **updated_at (datetime)**: Experiment last update date.
+    """
+
     name: Optional[str]
     description: Optional[str]
     updated_at: datetime = Field(default_factory=datetime.now)

--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -8,11 +8,38 @@ from app.models.dataset import Dataset
 
 
 class DatasetInIteration(BaseModel):
+    """
+    Dataset in iteration model.
+
+    Attributes:
+    - **id (PydanticObjectId)**: Dataset id.
+    - **name (Optional[str])**: Dataset name.
+    """
+
     id: PydanticObjectId
     name: Optional[str] = None
 
 
 class Iteration(BaseModel):
+    """
+    Iteration model.
+
+    Attributes:
+    - **id (PydanticObjectId)**: Iteration id.
+    - **experiment_id (PydanticObjectId)**: Experiment id.
+    - **project_id (PydanticObjectId)**: Project id.
+    - **experiment_name (str)**: Experiment name.
+    - **project_title (str)**: Project title.
+    - **user_name (str)**: User name.
+    - **iteration_name (str)**: Iteration title.
+    - **created_at (datetime)**: Iteration creation date.
+    - **metrics (Optional[dict])**: Iteration metrics.
+    - **parameters (Optional[dict])**: Iteration parameters.
+    - **path_to_model (Optional[str])**: Path to model.
+    - **model_name (Optional[str])**: Model name.
+    - **dataset (Optional[DatasetInIteration])**: Dataset.
+    """
+
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     experiment_id: PydanticObjectId = Field(default=None,  alias="experiment_id")
     project_id: PydanticObjectId = Field(default=None, alias="project_id")
@@ -77,6 +104,13 @@ class Iteration(BaseModel):
 
 
 class UpdateIteration(Iteration):
+    """
+    Update iteration model.
+
+    Attributes:
+    - **iteration_name (str)**: Iteration title.
+    """
+
     iteration_name: Optional[str]
 
     class Config:

--- a/back-end/app/models/project.py
+++ b/back-end/app/models/project.py
@@ -8,6 +8,20 @@ from app.models.experiment import Experiment
 
 
 class Project(Document):
+    """
+    Project model.
+
+    Attributes:
+    - **id (str)**: Project ID.
+    - **title (str)**: Project title.
+    - **description (str)**: Project description.
+    - **status (str)**: Project status.
+    - **archived (bool)**: Project archived status.
+    - **created_at (datetime)**: Project creation date.
+    - **updated_at (datetime)**: Project last update date.
+    - **experiments (List[Experiment])**: List of experiments in the project.
+    """
+
     title: str = Field(description="Project title", min_length=1, max_length=40)
     description: Optional[str] = Field(default="", description="Project description", max_length=150)
     status: str = Field(default='not_started', description="Project status")
@@ -54,6 +68,17 @@ class Project(Document):
 
 
 class UpdateProject(Project):
+    """
+    Update project model.
+
+    Attributes:
+    - **title (str)**: Project title.
+    - **description (str)**: Project description.
+    - **status (str)**: Project status.
+    - **archived (bool)**: Project archived status.
+    - **updated_at (datetime)**: Project last update date.
+    """
+
     title: Optional[str]
     description: Optional[str]
     status: Optional[str]
@@ -72,6 +97,20 @@ class UpdateProject(Project):
 
 
 class DisplayProject(Project):
+    """
+    Display project model.
+
+    Attributes:
+    - **id (str)**: Project ID.
+    - **title (str)**: Project title.
+    - **description (str)**: Project description.
+    - **status (str)**: Project status.
+    - **archived (bool)**: Project archived status.
+    - **created_at (datetime)**: Project creation date.
+    - **updated_at (datetime)**: Project last update date.
+    - **experiments (List[str])**: List of experiments in the project.
+    """
+
     experiments: List[str] = []
 
     class Config:

--- a/back-end/app/routers/project.py
+++ b/back-end/app/routers/project.py
@@ -90,12 +90,8 @@ async def get_project_base(id: PydanticObjectId) -> DisplayProject:
         archived=project.archived,
         created_at=project.created_at,
         updated_at=project.updated_at,
-        experiments=[]
+        experiments=[experiment.name for experiment in project.experiments]
     )
-
-    experiments_names = [experiment.name for experiment in project.experiments]
-
-    display_project.experiments = experiments_names
 
     return display_project
 
@@ -167,13 +163,13 @@ async def add_project(project: Project) -> Project:
     return project
 
 
-@router.put("/{id}", response_model=Project, status_code=status.HTTP_200_OK)
-async def update_project(id: PydanticObjectId, updated_project: UpdateProject) -> Project:
+@router.put("/{id}", response_model=DisplayProject, status_code=status.HTTP_200_OK)
+async def update_project(id: PydanticObjectId, updated_project: UpdateProject) -> DisplayProject:
     """
     Update project.
 
     Args:
-    - **id** (PydanticObjectId): Project id.
+    - **id** (PydanticObjectId)**: Project id.
 
     Returns:
     - **Project**: Updated project.
@@ -190,7 +186,18 @@ async def update_project(id: PydanticObjectId, updated_project: UpdateProject) -
     await project.update({"$set": updated_project.dict(exclude_unset=True)})
     await project.save()
 
-    return project
+    display_project = DisplayProject(
+        id=project.id,
+        title=project.title,
+        description=project.description,
+        status=project.status,
+        archived=project.archived,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+        experiments=[experiment.name for experiment in project.experiments]
+    )
+
+    return display_project
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Project update endpoint has been changed to return a List of experiment names rather than the entire experiments. Moreover, docstrings in Project, UpdateProject, DisplayProject, Experiment, UpdateExperiment, Iteration, UpdateIteration, DatasetInIteration, Dataset and UpdateDataset models have been added.