### PR TITLE
#MLOPS-156 Added archived parameter to Dataset model and code refactoring

### DIFF
--- a/back-end/app/app.py
+++ b/back-end/app/app.py
@@ -11,7 +11,7 @@ from app.routers.dataset import dataset_router as dataset_router
 app = FastAPI(title=settings.PROJECT_NAME)
 app.include_router(project_router, tags=["Project"], prefix="/projects")
 app.include_router(experiment_router, tags=["Experiment"], prefix="/projects/{project_id}/experiments")
-app.include_router(iteration_router, tags=['Iteration'], prefix="/projects/{project_id}/experiments/{experiment_id}/""iterations")
+app.include_router(iteration_router, tags=['Iteration'], prefix="/projects/{project_id}/experiments/{experiment_id}/iterations")
 app.include_router(dataset_router, tags=["Dataset"], prefix="/datasets")
 
 # front-end communication purpose

--- a/back-end/app/models/chart.py
+++ b/back-end/app/models/chart.py
@@ -19,20 +19,19 @@ class InteractiveChart(BaseModel):
     """
 
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
-    chart_name: str = Field(..., description="Chart name", min_length=1, max_length=100)
-    chart_type: str = Field(..., description="Chart type", min_length=1, max_length=100)
-    x_data: List[float] = Field(..., description="X axis data")
-    y_data: List[float] = Field(..., description="Y axis data")
+    chart_name: str = Field(description="Chart name", min_length=1, max_length=100)
+    chart_type: str = Field(description="Chart type", min_length=1, max_length=100)
+    x_data: List[float] = Field(description="X axis data")
+    y_data: List[float] = Field(description="Y axis data")
     x_label: Optional[str] = Field(default="x", description="X label", min_length=1, max_length=100)
     y_label: Optional[str] = Field(default="y", description="Y label", min_length=1, max_length=100)
 
     @validator('chart_type')
     def validate_status(cls, v):
-        chart_types = ['scatter', 'line', 'bar', 'pie', 'candlestick', 'heatmap', 'boxplot', 'histogram']
-        if v not in chart_types:
+        if v not in cls.Settings.chart_types:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Status must be one of {chart_types}"
+                detail=f"Status must be one of {cls.Settings.chart_types}"
             )
         return v
 
@@ -63,6 +62,7 @@ class InteractiveChart(BaseModel):
 
     class Settings:
         name = "InteractiveChart"
+        chart_types = ['scatter', 'line', 'bar', 'pie', 'candlestick', 'heatmap', 'boxplot', 'histogram']
 
     class Config:
         schema_extra = {

--- a/back-end/app/models/project.py
+++ b/back-end/app/models/project.py
@@ -1,4 +1,4 @@
-from beanie import Document, before_event, Replace, Insert
+from beanie import Document
 from pydantic import Field, validator
 from typing import Optional, List
 from datetime import datetime
@@ -32,11 +32,10 @@ class Project(Document):
 
     @validator('status')
     def validate_status(cls, v):
-        valid_statuses = ['not_started', 'in_progress', 'completed']
-        if v not in valid_statuses:
+        if v not in cls.Settings.valid_statuses:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Status must be one of {valid_statuses}"
+                detail=f"Status must be one of {cls.Settings.valid_statuses}"
             )
         return v
 
@@ -54,9 +53,9 @@ class Project(Document):
             return self.id == other.id
         return False
 
-
     class Settings:
         name = "project"
+        valid_statuses = ['not_started', 'in_progress', 'completed']
 
     class Config:
         schema_extra = {

--- a/back-end/app/tests/routers/test_dataset.py
+++ b/back-end/app/tests/routers/test_dataset.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import pytest
@@ -38,7 +37,8 @@ async def test_create_dataset_url(client: AsyncClient):
     dataset = {
         "dataset_name": "Test dataset",
         "dataset_description": "Test dataset description",
-        "dataset_type": "Test dataset type",
+        "tags": "Test, dataset",
+        "archived": False,
         "version": "0.0.0",
         "path_to_dataset": "https://www.kaggle.com/c/titanic/download/train.csv"
     }
@@ -63,7 +63,8 @@ async def test_get_dataset_by_id(client: AsyncClient):
     dataset = {
         "dataset_name": "Test dataset 2",
         "dataset_description": "Test dataset description 2",
-        "dataset_type": "Test dataset type",
+        "tags": "Test, dataset",
+        "archived": False,
         "version": "0.0.0",
         "path_to_dataset": "https://www.kaggle.com/c/titanic/download/train.csv"
     }
@@ -93,7 +94,8 @@ async def test_create_dataset_filepath(client: AsyncClient):
     dataset = {
         "dataset_name": "Test dataset 3",
         "dataset_description": "Test dataset description 3",
-        "dataset_type": "Test dataset type",
+        "tags": "Test, dataset",
+        "archived": True,
         "version": "0.0.0",
         "path_to_dataset": test_file_path
     }
@@ -135,7 +137,8 @@ async def test_get_dataset_by_name(client: AsyncClient):
     dataset = {
         "dataset_name": "Test dataset 4",
         "dataset_description": "Test dataset description 4",
-        "dataset_type": "Test dataset type",
+        "tags": "Test, dataset",
+        "archived": False,
         "version": "0.0.0",
         "path_to_dataset": "https://www.kaggle.com/c/titanic/data",
     }
@@ -165,7 +168,8 @@ async def test_update_dataset(client: AsyncClient):
 
     updated_dataset = { "dataset_name": "Test dataset 4 updated",
                         "dataset_description": "Test dataset description 4 updated",
-                        "dataset_type": "Test dataset type updated",
+                        "tags": "Test, dataset, changed",
+                        "archived": True,
                         "version": "0.0.2"}
 
     response = await client.get(f"/datasets/name/{dataset_name}")
@@ -251,3 +255,37 @@ async def test_delete_dataset_with_linked_iteration(client: AsyncClient):
 
     assert response.status_code == 200
     assert response.json()["dataset"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_non_archived_datasets(client: AsyncClient):
+    """
+    Test get non archived datasets.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+
+    response = await client.get("/datasets/non-archived")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_archived_datasets(client: AsyncClient):
+    """
+    Test get archived datasets.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+
+    response = await client.get("/datasets/archived")
+    assert response.status_code == 200
+    assert len(response.json()) == 0

--- a/back-end/app/tests/routers/test_iteration.py
+++ b/back-end/app/tests/routers/test_iteration.py
@@ -251,7 +251,8 @@ async def test_delete_iteration_with_dataset(client: AsyncClient):
     dataset = {
         "dataset_name": "Test dataset in iteration",
         "dataset_description": "Test dataset description",
-        "dataset_type": "Test dataset type",
+        "tags": "Test, dataset",
+        "archived": False,
         "version": "0.0.0",
         "path_to_dataset": "https://www.kaggle.com/c/titanic/data",
     }


### PR DESCRIPTION
- 'archived' parameter was added to Dataset model.
- 'dataset_problem_type' parameter was changed to 'tags'
- @validator in Dataset model was removed and util function 'validate_path' was added to dataset router since we want to only use @validator in POST and PUT methods. And it was done to optimize the program
- 'valid_statuses' list from Project model and 'chart_types' from InteractiveChart model were removed from @validator and were added to the Settings class in their classes
- added endpoint get_non_archived_datasets
- added endpoint get_archvied_datasets