### PR TITLE
#MLOPS-157-158 Back-end fixes

### DIFF
--- a/back-end/app/models/chart.py
+++ b/back-end/app/models/chart.py
@@ -21,8 +21,8 @@ class InteractiveChart(BaseModel):
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     chart_name: str = Field(description="Chart name", min_length=1, max_length=100)
     chart_type: str = Field(description="Chart type", min_length=1, max_length=100)
-    x_data: List[float] = Field(description="X axis data")
-    y_data: List[float] = Field(description="Y axis data")
+    x_data: List = Field(description="X axis data")
+    y_data: List = Field(description="Y axis data")
     x_label: Optional[str] = Field(default="x", description="X label", min_length=1, max_length=100)
     y_label: Optional[str] = Field(default="y", description="Y label", min_length=1, max_length=100)
 

--- a/back-end/app/models/dataset.py
+++ b/back-end/app/models/dataset.py
@@ -21,7 +21,6 @@ class Dataset(Document):
     - **version** (str): Dataset version
     - **linked_iterations** (Dict): Linked iterations (key - iteration id, value - (project_id, experiment_id)
     """
-
     dataset_name: str = Field(description="Dataset name", min_length=1, max_length=40)
     path_to_dataset: str = Field(default='', description="Path to dataset")
     dataset_description: Optional[str] = Field(default='', description="Dataset description", max_length=150)

--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -15,10 +15,11 @@ class DatasetInIteration(BaseModel):
     Attributes:
     - **id (PydanticObjectId)**: Dataset id.
     - **name (Optional[str])**: Dataset name.
+    - **version (Optional[str])**: Dataset version.
     """
-
-    id: PydanticObjectId
-    name: Optional[str] = None
+    id: PydanticObjectId = Field(..., description="Dataset id")
+    name: Optional[str] = Field(default=None, description="Dataset name")
+    version: Optional[str] = Field(default=None, description="Dataset version")
 
 
 class Iteration(BaseModel):
@@ -99,8 +100,7 @@ class Iteration(BaseModel):
                 "path_to_model": "model.pkl",
                 "model_name": "model",
                 "dataset": {
-                    "id": "5f9b3b7e9c9d6c0a3c7b3b7e",
-                    "name": "Dataset Titanic"
+                    "id": "5f9b3b7e9c9d6c0a3c7b3b7e"
                 },
                 "interactive_charts": [
                     {

--- a/back-end/app/routers/experiment.py
+++ b/back-end/app/routers/experiment.py
@@ -141,6 +141,7 @@ async def update_experiment(project_id: PydanticObjectId, id: PydanticObjectId,
     experiment.description = updated_experiment.description or experiment.description
     experiment.updated_at = datetime.now()
 
+    await update_iteration_experiment_name(project, experiment)
     await project.save()
 
     return experiment
@@ -272,3 +273,20 @@ async def delete_iteration_from_dataset_deleting_iterations(iteration: Iteration
     await dataset.save()
 
     return None
+
+
+async def update_iteration_experiment_name(project: Project, experiment: Experiment) -> None:
+    """
+    Util function for updating experiment name inside iteration.
+
+    Args:
+        project: Project.
+        experiment: Experiment.
+
+    Returns:
+        None
+    """
+    for iteration in experiment.iterations:
+        iteration.experiment_name = experiment.name
+
+    await project.save()

--- a/back-end/app/routers/iteration.py
+++ b/back-end/app/routers/iteration.py
@@ -7,7 +7,6 @@ from typing import List, Dict
 from app.models.dataset import Dataset
 from app.models.iteration import Iteration, UpdateIteration
 from app.models.project import Project
-from app.models.chart import InteractiveChart
 from app.routers.exceptions.chart import chart_name_in_iteration_not_unique_exception
 from app.routers.exceptions.dataset import dataset_not_found_exception
 from app.routers.exceptions.experiment import experiment_not_found_exception
@@ -57,7 +56,6 @@ async def get_iteration(project_id: PydanticObjectId, experiment_id: PydanticObj
     Returns:
     - **Iteration**: Iteration
     """
-
     project = await Project.get(project_id)
     if not project:
         raise project_not_found_exception()
@@ -87,7 +85,6 @@ async def get_iterations_by_name(project_id: PydanticObjectId, experiment_id: Py
     Returns:
     - **List[Iteration]**: List of iterations with selected name
     """
-
     project = await Project.get(project_id)
     if not project:
         raise project_not_found_exception()
@@ -118,7 +115,6 @@ async def add_iteration(project_id: PydanticObjectId, experiment_id: PydanticObj
     Returns:
     - **Iteration**: Iteration added to experiment
     """
-
     project = await Project.get(project_id)
     if not project:
         raise project_not_found_exception()
@@ -139,6 +135,14 @@ async def add_iteration(project_id: PydanticObjectId, experiment_id: PydanticObj
             raise chart_name_in_iteration_not_unique_exception()
 
     if iteration.dataset:
+        dataset = await Dataset.get(iteration.dataset.id)
+        if not dataset:
+            raise dataset_not_found_exception()
+
+        # set iteration dataset name and version automatically based on given id
+        iteration.dataset.name = dataset.dataset_name
+        iteration.dataset.version = dataset.version
+
         await add_iteration_to_dataset_linked_iterations(iteration)
 
     experiment.iterations.append(iteration)
@@ -162,7 +166,6 @@ async def update_iteration(project_id: PydanticObjectId, experiment_id: Pydantic
     Returns:
     - **Iteration**: Updated iteration
     """
-
     project = await Project.get(project_id)
     if not project:
         raise project_not_found_exception()
@@ -195,7 +198,6 @@ async def delete_iteration(project_id: PydanticObjectId, experiment_id: Pydantic
     Returns:
     - **None**: None
     """
-
     project = await Project.get(project_id)
     if not project:
         raise project_not_found_exception()

--- a/back-end/app/routers/project.py
+++ b/back-end/app/routers/project.py
@@ -6,6 +6,7 @@ from typing import List, Dict
 
 from app.models.dataset import Dataset
 from app.models.experiment import Experiment
+from app.models.iteration import Iteration
 from app.models.project import Project, UpdateProject, DisplayProject
 from app.routers.exceptions.dataset import dataset_not_found_exception
 from app.routers.exceptions.project import (
@@ -186,6 +187,8 @@ async def update_project(id: PydanticObjectId, updated_project: UpdateProject) -
     await project.update({"$set": updated_project.dict(exclude_unset=True)})
     await project.save()
 
+    await update_iteration_project_title(project)
+
     display_project = DisplayProject(
         id=project.id,
         title=project.title,
@@ -281,3 +284,20 @@ async def delete_iterations_from_dataset_deleting_project(experiments: List[Expe
                 await dataset.save()
 
     return None
+
+
+async def update_iteration_project_title(project: Project) -> None:
+    """
+    Util function for updating project title inside iteration.
+
+    Args:
+        project: Project.
+
+    Returns:
+        None
+    """
+    for experiment in project.experiments:
+        for iteration in experiment.iterations:
+            iteration.project_title = project.title
+
+    await project.save()


### PR DESCRIPTION
Some back-end fixes that involve:
- Added `version` attribute to dataset inside Iteration
- Updated logic for logging dataset to iteration, now you have to only pass dataset `id`. After that `name` and `version` will be automatically updated based on passed `id`
- Fixed problem when updating project/experiment name doesn't change `project_title`/`experiment_name` attributes inside Iteration class
- For chart model `x_data`, `y_data` attributes, strings are also allowed as values now

All above fixes have been unit-tested.