### PR TITLE
#MLOPS-165 Fixed docker timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - .env
     environment:
       - MONGODB_URL=${MONGODB_URL_DEPLOY}
+      - TZ=${TZ}
     ports:
       - ${FASTAPI_PORT}:${FASTAPI_PORT}
 
@@ -25,6 +26,8 @@ services:
       - /app/node_modules
     env_file:
       - .env
+    environment:
+      - TZ=${TZ}
     ports:
       - ${REACT_PORT}:${REACT_PORT}
 
@@ -36,4 +39,6 @@ services:
       - ./back-end/.env
     ports:
       - ${MONGODB_PORT}:${MONGODB_PORT}
+    environment:
+     - TZ=${TZ}
     command: mongod --quiet --logpath /dev/null


### PR DESCRIPTION
Fixed docker timezone problem, for now it's set inside .env file as `TZ=Europe/Warsaw`. 
In future we may write some bash script to retrieve it automatically based on actual host TZ.

U can find updated .env file on discord. 