### PR TITLE
#MLOPS-166 Docker model/dataset local paths fixes

### DIFF
--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -1,4 +1,3 @@
-import os
 import getpass
 from pydantic import Field, BaseModel, validator
 from datetime import datetime
@@ -6,8 +5,6 @@ from typing import Optional, Dict, List
 from beanie import PydanticObjectId
 from app.models.chart import InteractiveChart
 from app.models.image_chart import ImageChart
-
-from app.routers.exceptions.iteration import model_path_not_exist_exception
 
 
 class DatasetInIteration(BaseModel):
@@ -60,21 +57,6 @@ class Iteration(BaseModel):
     dataset: Optional[DatasetInIteration] = Field(default=None, description="Dataset")
     interactive_charts: Optional[List[InteractiveChart]] = Field(default=None, description="Interactive charts list")
     image_charts: Optional[List[ImageChart]] = Field(default=None, description="Image charts list")
-
-    @validator('path_to_model')
-    def path_to_model_exists(cls, path):
-        if not path:
-            return path
-        path = r'{}'.format(path)
-        if os.path.isfile(path):
-            return path
-        else:
-            # Change the current working directory to the root directory
-            os.chdir('/')
-            if os.path.isfile(path):
-                return path
-            else:
-                raise model_path_not_exist_exception()
 
     def __repr__(self) -> str:
         return f"<Iteration {self.iteration_name}>"

--- a/back-end/app/routers/dataset.py
+++ b/back-end/app/routers/dataset.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import validators
 
 from datetime import datetime
 from typing import List, Optional
@@ -227,12 +228,9 @@ async def validate_path(value):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Path or URL is empty. "
                                                                           "Please, enter path or URL.")
 
-    if os.path.isfile(r'{}'.format(value)):
+    # if value is not url type, just return it as it is
+    if not validators.url(value):
         return value
-    else:
-        os.chdir('/')  # Change the current working directory to the root directory
-        if os.path.isfile(r'{}'.format(value)):
-            return value
 
     try:
         response = requests.head(value)
@@ -243,4 +241,4 @@ async def validate_path(value):
                                                                               "returns an error.")
     except requests.exceptions.RequestException:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invalid URL or unable to connect to "
-                                                                          "the URL or invalid path.")
+                                                                          "the URL.")

--- a/back-end/app/routers/exceptions/iteration.py
+++ b/back-end/app/routers/exceptions/iteration.py
@@ -6,10 +6,3 @@ def iteration_not_found_exception():
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Iteration not found."
     )
-
-
-def model_path_not_exist_exception():
-    return HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="Model path does not exist."
-    )

--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -7,4 +7,5 @@ httpx ~= 0.24.0
 asgi_lifespan ~= 2.1.0
 pytest-asyncio ~= 0.21.0
 requests ~= 2.29.0
+validators ~= 0.20.0
 mlops-ai

--- a/library/mlops/exceptions/iteration.py
+++ b/library/mlops/exceptions/iteration.py
@@ -4,3 +4,7 @@ from requests import Response
 def iteration_request_failed_exception(response: Response):
     detail = response.json()['detail']
     return Exception(f"Iteration not created. Request failed with status code {response.status_code}: {detail}")
+
+
+def model_path_not_exist_exception():
+    return FileNotFoundError("Provided model path does not exist.")

--- a/library/mlops/tracking.py
+++ b/library/mlops/tracking.py
@@ -7,6 +7,8 @@ from mlops.exceptions.tracking import project_id_is_none_exception, experiment_i
     failed_to_set_active_project_exception, failed_to_set_active_experiment_exception, request_failed_exception
 from typing import ContextManager
 
+from mlops.exceptions.iteration import model_path_not_exist_exception
+
 
 def get_project(project_id: str = None) -> dict:
     """
@@ -205,6 +207,29 @@ def set_active_experiment(experiment_id: str) -> str:
     return f"Active experiment set to: {settings.active_experiment_id}"
 
 
+def create_dataset(dataset_name: str, path_to_dataset: str, dataset_description: str = None,
+                   tags: str = None, version: str = None) -> dict:
+    """
+    Function for creating mlops datasets
+
+    Args:
+        dataset_name: name of the created dataset
+        path_to_dataset: path to dataset files
+        dataset_description: short description of the dataset displayed in the app
+        tags: tags for dataset
+        version: version of the dataset
+
+    Returns:
+        dataset: json data of created dataset
+    """
+
+    dataset = Dataset(dataset_name, path_to_dataset, dataset_description, tags, version)
+
+    app_response = dataset.create_dataset_in_app()
+
+    return app_response
+
+
 @contextmanager
 def start_iteration(iteration_name: str, project_id: str = None,
                     experiment_id: str = None) -> ContextManager[Iteration]:
@@ -237,27 +262,3 @@ def start_iteration(iteration_name: str, project_id: str = None,
         yield iteration
     finally:
         iteration.end_iteration()
-
-
-def create_dataset(dataset_name: str, path_to_dataset: str, dataset_description: str = None,
-                   tags: str = None, version: str = None) -> dict:
-    """
-    Function for creating mlops datasets
-
-    Args:
-        dataset_name: name of the created dataset
-        path_to_dataset: path to dataset files
-        dataset_description: short description of the dataset displayed in the app
-        tags: tags for dataset
-        version: version of the dataset
-
-    Returns:
-        dataset: json data of created dataset
-    """
-
-    dataset = Dataset(dataset_name, path_to_dataset, dataset_description, tags, version)
-
-    app_response = dataset.create_dataset_in_app()
-
-    return app_response
-

--- a/library/tests/unit_tests/test_iteration.py
+++ b/library/tests/unit_tests/test_iteration.py
@@ -72,7 +72,8 @@ def test_single_backslash_path_formatting(setup):
 
 
 def test_log_dataset(setup):
-    dataset = mlops.tracking.create_dataset(dataset_name='test_dataset')
+    dataset = mlops.tracking.create_dataset(dataset_name='test_dataset',
+                                            path_to_dataset="https://www.kaggle.com/c/titanic/data")
 
     iteration = Iteration(
         iteration_name='test_iteration',
@@ -82,4 +83,4 @@ def test_log_dataset(setup):
 
     iteration.log_dataset(dataset["_id"])
 
-    assert iteration.dataset.dataset_name == 'test_dataset'
+    assert iteration.dataset_name == 'test_dataset'

--- a/library/tests/unit_tests/test_tracking.py
+++ b/library/tests/unit_tests/test_tracking.py
@@ -215,6 +215,42 @@ async def test_start_iteration_with_multiple_params_and_metrics(setup):
 
 
 @pytest.mark.asyncio
+async def test_start_iteration_with_path_to_model(setup):
+    await drop_database()
+
+    project = mlops.tracking.create_project(title='test_project')
+    experiment = mlops.tracking.create_experiment(name='test_experiment', project_id=project['_id'])
+
+    with mlops.tracking.start_iteration('test_iteration', project_id=project['_id'],
+                                        experiment_id=experiment['id']) as iteration:
+        iteration.log_model_name('test_iteration')
+        iteration.log_path_to_model('../../mlops/tracking.py')
+
+    result = iteration.end_iteration()
+
+    assert result['iteration_name'] == 'test_iteration'
+    assert result['path_to_model'] == '..\\..\\mlops\\tracking.py'
+
+
+@pytest.mark.asyncio
+async def test_start_iteration_with_invalid_path_to_model(setup):
+    await drop_database()
+
+    project = mlops.tracking.create_project(title='test_project')
+    experiment = mlops.tracking.create_experiment(name='test_experiment', project_id=project['_id'])
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        with mlops.tracking.start_iteration('test_iteration', project_id=project['_id'],
+                                            experiment_id=experiment['id']) as iteration:
+            iteration.log_model_name('test_iteration')
+            iteration.log_path_to_model('INVALID PATH')
+
+        result = iteration.end_iteration()
+
+    assert str(exc_info.value) == 'Provided model path does not exist.'
+
+
+@pytest.mark.asyncio
 async def test_start_iteration_with_dataset(setup):
     await drop_database()
 


### PR DESCRIPTION
It was hard to include local file paths for Docker as it as, so some refactors has been needed:
- for validating iteration `path_to_model`, validation has been moved from back-end to library side
- for dataset `path_to_dataset`, validation is still on the back-end side, however validation includes only URLs, local files validation has been removed
- also validating image_chart path will be done on library side when implementing [MLOPS-162](https://jira.wmi.amu.edu.pl/browse/MLOPS-162)