### PR TITLE
[MLOPS-205-206-207] Added MonitoredModel class and monitored_model routers ( CRUD )

### DIFF
--- a/back-end/.env
+++ b/back-end/.env
@@ -1,4 +1,4 @@
 MONGODB_URL=mongodb://localhost:27017/
 MONGODB_DB_NAME=mlops
-TESTING=False
+TESTING=True
 MONGODB_TEST_DB_NAME=mlops_test

--- a/back-end/app/app.py
+++ b/back-end/app/app.py
@@ -7,12 +7,14 @@ from app.routers.project import router as project_router
 from app.routers.experiment import experiment_router as experiment_router
 from app.routers.iteration import iteration_router as iteration_router
 from app.routers.dataset import dataset_router as dataset_router
+from app.routers.monitored_model import monitored_model_router as monitored_model_router
 
 app = FastAPI(title=settings.PROJECT_NAME)
 app.include_router(project_router, tags=["Project"], prefix="/projects")
 app.include_router(experiment_router, tags=["Experiment"], prefix="/projects/{project_id}/experiments")
 app.include_router(iteration_router, tags=['Iteration'], prefix="/projects/{project_id}/experiments/{experiment_id}/iterations")
 app.include_router(dataset_router, tags=["Dataset"], prefix="/datasets")
+app.include_router(monitored_model_router, tags=["Monitored model"], prefix="/monitored-models")
 
 # front-end communication purpose
 app.add_middleware(

--- a/back-end/app/database/init_mongo_db.py
+++ b/back-end/app/database/init_mongo_db.py
@@ -1,6 +1,7 @@
 from app.config.config import settings
 from app.models.project import Project
 from app.models.dataset import Dataset
+from app.models.monitored_model import MonitoredModel
 
 from beanie import init_beanie
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -18,7 +19,8 @@ async def init_mongo_db():
         database=db_client[db_name],
         document_models=[
             Project,
-            Dataset
+            Dataset,
+            MonitoredModel
         ]
     )
 

--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -37,7 +37,6 @@ class Iteration(BaseModel):
     - **metrics (Optional[dict])**: Iteration metrics.
     - **parameters (Optional[dict])**: Iteration parameters.
     - **path_to_model (Optional[str])**: Path to model.
-    - **model_name (Optional[str])**: Model name.
     - **dataset (Optional[DatasetInIteration])**: Dataset.
     - **interactive_charts (Optional[List[InteractiveChart]])**: Interactive charts list.
     """
@@ -53,7 +52,6 @@ class Iteration(BaseModel):
     metrics: Optional[dict] = Field(default=None, description="Iteration metrics")
     parameters: Optional[dict] = Field(default=None, description="Iteration parameters")
     path_to_model: Optional[str] = Field(default='', description="Path to model")
-    model_name: Optional[str] = Field(default="model", description="Model name", min_length=1, max_length=100)
     dataset: Optional[DatasetInIteration] = Field(default=None, description="Dataset")
     interactive_charts: Optional[List[InteractiveChart]] = Field(default=[], description="Interactive charts list")
     image_charts: Optional[List[ImageChart]] = Field(default=[], description="Image charts list")
@@ -83,7 +81,6 @@ class Iteration(BaseModel):
                 "metrics": {"accuracy": 0.9},
                 "parameters": {"batch_size": 32},
                 "path_to_model": "model.pkl",
-                "model_name": "model",
                 "dataset": {
                     "id": "5f9b3b7e9c9d6c0a3c7b3b7e"
                 },

--- a/back-end/app/models/iteration.py
+++ b/back-end/app/models/iteration.py
@@ -31,7 +31,7 @@ class Iteration(BaseModel):
     - **project_id (PydanticObjectId)**: Project id.
     - **experiment_name (str)**: Experiment name.
     - **project_title (str)**: Project title.
-    - **user_name (str)**: User name.
+    - **user_name (str)**: Username.
     - **iteration_name (str)**: Iteration title.
     - **created_at (datetime)**: Iteration creation date.
     - **metrics (Optional[dict])**: Iteration metrics.

--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -78,3 +78,46 @@ class MonitoredModel(Document):
                 }
             }
         }
+
+
+class UpdateMonitoredModel(MonitoredModel):
+    """
+    Class for update monitored model.
+
+    Attributes:
+    - **model_name (str)**: Monitored model name.
+    - **model_description (str)**: Monitored model description.
+    - **model_status (str)**: Monitored model status.
+    - **iteration (Iteration)**: Related Iteration.
+    """
+
+    model_name: Optional[str]
+    model_description: Optional[str]
+    model_status: Optional[str]
+    iteration: Optional[Iteration]
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "model_name": "Titanic",
+                "description": "Titanic model",
+                "status": "archived",
+                "iteration": {
+                    "id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "experiment_name": "Experiment 1",
+                    "project_title": "Project 1",
+                    "user_name": getpass.getuser(),
+                    "iteration_name": "Iteration 1",
+                    "path_to_model": "model.pkl",
+                    "model_name": "model",
+                    "image_charts": [
+                        {
+                            "name": "Chart 1",
+                            "encoded_image": "..."
+                        }
+                    ]
+                }
+            }
+        }

--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -1,0 +1,80 @@
+import getpass
+from pydantic import Field, validator
+from typing import Optional
+from beanie import Document
+from fastapi import HTTPException, status
+
+from app.models.iteration import Iteration
+
+
+class MonitoredModel(Document):
+    """
+    Monitored model.
+
+    Attributes:
+    - **id (PydanticObjectId)**: Monitored model id.
+    - **model_name (str)**: Monitored model name.
+    - **model_description (str)**: Monitored model description.
+    - **model_status (str)**: Monitored model status.
+    - **iteration (Iteration)**: Related Iteration.
+    - **ml_model (object)**: ML model. ---- TODO: add coded pkl file
+    """
+
+    model_name: str = Field(default=None, description="Model name", min_length=1, max_length=100)
+    model_description: Optional[str] = Field(default="", description="Model description", max_length=150)
+    model_status: str = Field(default='idle', description="Model status")
+    iteration: Optional[Iteration] = Field(default=None, description="Iteration")
+    #ml_model: Optional[str] = Field(default=None, description="path to model")
+
+    @validator('model_status')
+    def validate_status(cls, v):
+        if v not in cls.Settings.valid_statuses:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Status must be one of {cls.Settings.valid_statuses}"
+            )
+        return v
+
+    def __repr__(self) -> str:
+        return f"<Monitored model {self.model_name}>"
+
+    def __str__(self) -> str:
+        return self.model_name
+
+    def __hash__(self) -> int:
+        return hash(self.model_name)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, MonitoredModel):
+            return self.id == other.id
+        return False
+
+    class Settings:
+        name = "monitored_model"
+        valid_statuses = ['active', 'idle', 'archived']
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "model_name": "Approximate value of the plot",
+                "model_description": "Predicting approximate value of the plot based on given parameters",
+                "model_status": "active",
+                "iteration": {
+                    "id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+                    "experiment_name": "Experiment 1",
+                    "project_title": "Project 1",
+                    "user_name": getpass.getuser(),
+                    "iteration_name": "Iteration 1",
+                    "path_to_model": "model.pkl",
+                    "model_name": "model",
+                    "image_charts": [
+                        {
+                            "name": "Chart 1",
+                            "encoded_image": "..."
+                        }
+                    ]
+                }
+            }
+        }

--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -20,7 +20,7 @@ class MonitoredModel(Document):
     - **ml_model (object)**: ML model. ---- TODO: add coded pkl file
     """
 
-    model_name: str = Field(default=None, description="Model name", min_length=1, max_length=100)
+    model_name: str = Field(description="Model name", min_length=1, max_length=100)
     model_description: Optional[str] = Field(default="", description="Model description", max_length=150)
     model_status: str = Field(default='idle', description="Model status")
     iteration: Optional[Iteration] = Field(default=None, description="Iteration")
@@ -68,7 +68,6 @@ class MonitoredModel(Document):
                     "user_name": getpass.getuser(),
                     "iteration_name": "Iteration 1",
                     "path_to_model": "model.pkl",
-                    "model_name": "model",
                     "image_charts": [
                         {
                             "name": "Chart 1",
@@ -100,8 +99,8 @@ class UpdateMonitoredModel(MonitoredModel):
         schema_extra = {
             "example": {
                 "model_name": "Titanic",
-                "description": "Titanic model",
-                "status": "archived",
+                "model_description": "Titanic model",
+                "model_status": "archived",
                 "iteration": {
                     "id": "5f9b3b7e9c9d6c0a3c7b3b7e",
                     "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
@@ -111,7 +110,6 @@ class UpdateMonitoredModel(MonitoredModel):
                     "user_name": getpass.getuser(),
                     "iteration_name": "Iteration 1",
                     "path_to_model": "model.pkl",
-                    "model_name": "model",
                     "image_charts": [
                         {
                             "name": "Chart 1",

--- a/back-end/app/routers/exceptions/monitored_model.py
+++ b/back-end/app/routers/exceptions/monitored_model.py
@@ -13,3 +13,17 @@ def monitored_model_name_not_unique_exception():
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="Monitored model name already exists."
     )
+
+
+def monitored_model_has_no_iteration_exception():
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Monitored model has no iteration. Model status must be 'idle' or 'archived'."
+    )
+
+
+def monitored_model_has_iteration_exception():
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Monitored model has iteration. Model status must be 'active' or 'archived'."
+    )

--- a/back-end/app/routers/exceptions/monitored_model.py
+++ b/back-end/app/routers/exceptions/monitored_model.py
@@ -1,0 +1,15 @@
+from fastapi import HTTPException, status
+
+
+def monitored_model_not_found_exception():
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Monitored model not found."
+    )
+
+
+def monitored_model_name_not_unique_exception():
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Monitored model name already exists."
+    )

--- a/back-end/app/routers/monitored_model.py
+++ b/back-end/app/routers/monitored_model.py
@@ -1,0 +1,206 @@
+from typing import List
+
+from beanie import PydanticObjectId
+from fastapi import APIRouter, status
+
+from app.models.monitored_model import MonitoredModel
+from app.routers.exceptions.monitored_model import monitored_model_not_found_exception, \
+    monitored_model_name_not_unique_exception
+
+monitored_model_router = APIRouter()
+
+
+@monitored_model_router.get("/", response_model=List[MonitoredModel], status_code=status.HTTP_200_OK)
+async def get_all_monitored_models() -> List[MonitoredModel]:
+    """
+    Get all monitored models.
+
+    Args:
+    - **None**
+
+    Returns:
+    - **List[MonitoredModel]**: List of all monitored models.
+    """
+    monitored_models = await MonitoredModel.find_all().to_list()
+    return monitored_models
+
+
+@monitored_model_router.get("/non-archived", response_model=List[MonitoredModel], status_code=status.HTTP_200_OK)
+async def get_non_archived_monitored_models() -> List[MonitoredModel]:
+    """
+    Get all non-archived monitored models.
+
+    Args:
+    - **None**
+
+    Returns:
+    - **List[MonitoredModel]**: List of all non-archived monitored models.
+    """
+    monitored_models = await MonitoredModel.find(MonitoredModel.model_status != 'archived').to_list()
+    return monitored_models
+
+
+@monitored_model_router.get("/archived", response_model=List[MonitoredModel], status_code=status.HTTP_200_OK)
+async def get_archived_monitored_models() -> List[MonitoredModel]:
+    """
+    Get all archived monitored models.
+
+    Args:
+    - **None**
+
+    Returns:
+    - **List[MonitoredModel]**: List of all archived monitored models.
+    """
+    monitored_models = await MonitoredModel.find(MonitoredModel.model_status == 'archived').to_list()
+    return monitored_models
+
+
+@monitored_model_router.get("/active", response_model=List[MonitoredModel], status_code=status.HTTP_200_OK)
+async def get_active_monitored_models() -> List[MonitoredModel]:
+    """
+    Get all active monitored models.
+
+    Args:
+    - **None**
+
+    Returns:
+    - **List[MonitoredModel]**: List of all active monitored models.
+    """
+    monitored_models = await MonitoredModel.find(MonitoredModel.model_status == 'active').to_list()
+    return monitored_models
+
+
+@monitored_model_router.get("/idle", response_model=List[MonitoredModel], status_code=status.HTTP_200_OK)
+async def get_idle_monitored_models() -> List[MonitoredModel]:
+    """
+    Get all idle monitored models.
+
+    Args:
+    - **None**
+
+    Returns:
+    - **List[MonitoredModel]**: List of all idle monitored models.
+    """
+    monitored_models = await MonitoredModel.find(MonitoredModel.model_status == 'idle').to_list()
+    return monitored_models
+
+
+@monitored_model_router.get('/name/{name}', response_model=MonitoredModel, status_code=status.HTTP_200_OK)
+async def get_monitored_model_by_name(name: str) -> MonitoredModel:
+    """
+    Retrieve monitored model by name.
+
+    Args:
+    - **name (str)**: Monitored model name
+
+    Returns:
+    - **MonitoredModel**: Monitored model
+    """
+    monitored_model = await MonitoredModel.find_one(MonitoredModel.model_name == name)
+    if not monitored_model:
+        raise monitored_model_not_found_exception()
+
+    return monitored_model
+
+
+@monitored_model_router.get('/id/{id}', response_model=MonitoredModel, status_code=status.HTTP_200_OK)
+async def get_monitored_model_by_id(id: PydanticObjectId) -> MonitoredModel:
+    """
+    Retrieve monitored model by id.
+
+    Args:
+    - **id (str)**: Monitored model id
+
+    Returns:
+    - **MonitoredModel**: Monitored model
+    """
+    monitored_model = await MonitoredModel.find_one(MonitoredModel.id == id)
+    if not monitored_model:
+        raise monitored_model_not_found_exception()
+
+    return monitored_model
+
+
+@monitored_model_router.post("/", response_model=MonitoredModel, status_code=status.HTTP_201_CREATED)
+async def create_monitored_model(monitored_model: MonitoredModel) -> MonitoredModel:
+    """
+    Add new monitored model.
+
+    Args:
+    - **monitored_model** (MonitoredModel): Monitored model to add.
+
+    Returns:
+    - **MonitoredModel**: Added monitored model.
+    """
+    unique_name = await is_name_unique(monitored_model.model_name)
+    if not unique_name:
+        raise monitored_model_name_not_unique_exception()
+
+    monitored_model = await monitored_model.insert()
+    return monitored_model
+
+
+@monitored_model_router.put("/{id}", response_model=MonitoredModel, status_code=status.HTTP_200_OK)
+async def update_monitored_model(id: PydanticObjectId, monitored_model: MonitoredModel) -> MonitoredModel:
+    """
+    Update monitored model.
+
+    Args:
+    - **id (PydanticObjectId)**: Monitored model id
+    - **monitored_model (MonitoredModel)**: Monitored model to update
+
+    Returns:
+    - **MonitoredModel**: Updated monitored model
+    """
+    db_monitored_model = await MonitoredModel.get(id)
+    if not db_monitored_model:
+        raise monitored_model_not_found_exception()
+
+    unique_name = await is_name_unique(monitored_model.model_name)
+    if not unique_name:
+        raise monitored_model_name_not_unique_exception()
+
+    db_monitored_model.model_name = monitored_model.model_name
+    db_monitored_model.model_description = monitored_model.model_description
+    db_monitored_model.model_status = monitored_model.model_status
+    #db_monitored_model.ml_model = monitored_model.ml_model
+
+    await db_monitored_model.save()
+    return db_monitored_model
+
+
+@monitored_model_router.delete("/{id}", response_model=MonitoredModel, status_code=status.HTTP_200_OK)
+async def delete_monitored_model(id: PydanticObjectId) -> MonitoredModel:
+    """
+    Delete monitored model.
+
+    Args:
+    - **id (PydanticObjectId)**: Monitored model id
+
+    Returns:
+    - **MonitoredModel**: Deleted monitored model
+    """
+    monitored_model = await MonitoredModel.find_one(MonitoredModel.id == id)
+    if not monitored_model:
+        raise monitored_model_not_found_exception()
+
+    await monitored_model.delete()
+    return monitored_model
+
+
+async def is_name_unique(name: str) -> bool:
+    """
+    Util function for checking if monitored model name is unique.
+
+    Args:
+        name: Monitored model name to check.
+
+    Returns:
+        True if name is unique, False otherwise.
+    """
+    monitored_model = await MonitoredModel.find_one(
+        MonitoredModel.model_name == name
+    )
+    if monitored_model:
+        return False
+    return True

--- a/back-end/app/routers/monitored_model.py
+++ b/back-end/app/routers/monitored_model.py
@@ -162,11 +162,12 @@ async def update_monitored_model(id: PydanticObjectId, updated_monitored_model: 
     if not db_monitored_model:
         raise monitored_model_not_found_exception()
 
-    unique_name = await is_name_unique(updated_monitored_model.model_name)
-    if not unique_name:
-        raise monitored_model_name_not_unique_exception()
+    if updated_monitored_model.model_name is not None:
+        unique_name = await is_name_unique(updated_monitored_model.model_name)
+        if not unique_name:
+            raise monitored_model_name_not_unique_exception()
 
-    if updated_monitored_model.iteration is not None and updated_monitored_model.iteration != '':
+    if updated_monitored_model.iteration is not None:
         if updated_monitored_model.model_status == 'idle':
             raise monitored_model_has_iteration_exception()
         elif updated_monitored_model.model_status is None:
@@ -174,11 +175,13 @@ async def update_monitored_model(id: PydanticObjectId, updated_monitored_model: 
                 raise monitored_model_has_iteration_exception()
     elif updated_monitored_model.iteration is None:
         if db_monitored_model.iteration is not None:
-            if updated_monitored_model.model_status not in ('active', 'archived'):
-                raise monitored_model_has_iteration_exception()
+            if updated_monitored_model.model_status is not None:
+                if updated_monitored_model.model_status not in ('active', 'archived'):
+                    raise monitored_model_has_iteration_exception()
         else:
-            if updated_monitored_model.model_status not in ('idle', 'archived'):
-                raise monitored_model_has_no_iteration_exception()
+            if updated_monitored_model.model_status is not None:
+                if updated_monitored_model.model_status not in ('idle', 'archived'):
+                    raise monitored_model_has_no_iteration_exception()
 
     await db_monitored_model.update({"$set": updated_monitored_model.dict(exclude_unset=True)})
     # db_monitored_model.ml_model = monitored_model.ml_model

--- a/back-end/app/tests/routers/test_iteration.py
+++ b/back-end/app/tests/routers/test_iteration.py
@@ -69,8 +69,7 @@ async def test_add_iteration(client: AsyncClient):
     iteration = {
         "iteration_name": "Test iteration",
         "metrics": {"accuracy": 0.8, "precision": 0.7, "recall": 0.9, "f1": 0.75},
-        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.0001},
-        "model_name": "Test model name"
+        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.0001}
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
@@ -105,8 +104,7 @@ async def test_add_iteration2(client: AsyncClient):
         "iteration_name": "Test iteration 2",
         "metrics": {"accuracy": 0.9, "precision": 0.8, "recall": 0.7, "f1": 0.6},
         "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.001},
-        "path_to_model": test_file_path,
-        "model_name": "Test model name"
+        "path_to_model": test_file_path
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
@@ -193,8 +191,7 @@ async def test_change_iteration_name(client: AsyncClient):
     iteration = {
         "iteration_name": "Test iteration to change",
         "metrics": {"accuracy": 0.8, "precision": 0.7, "recall": 0.9, "f1": 0.75},
-        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.0001},
-        "model_name": "Test model name to change"
+        "parameters": {"batch_size": 32, "epochs": 10, "learning_rate": 0.0001}
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)

--- a/back-end/app/tests/routers/test_monitored_model.py
+++ b/back-end/app/tests/routers/test_monitored_model.py
@@ -1,0 +1,275 @@
+import pytest
+from httpx import AsyncClient
+
+from app.database.init_mongo_db import drop_database
+
+
+@pytest.mark.asyncio
+async def test_empty_get_monitored_models(client: AsyncClient):
+    """
+    Test get all monitored models when there are no monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    await drop_database()
+    response = await client.get("/monitored-models/")
+    assert response.status_code == 200
+    assert(len(response.json()) == 0)
+
+
+@pytest.mark.asyncio
+async def test_create_monitored_model(client: AsyncClient):
+    """
+    Test create monitored model.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    iteration = {
+        "iteration_name": "Test iteration",
+        "experiment_name": "Test experiment",
+        "project_title": "Test project",
+        "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "user_name": "Test user"
+    }
+
+    monitored_model = {
+        "model_name": "Test monitored model",
+        "model_description": "Test monitored model description",
+        "iteration": iteration
+    }
+
+    response = await client.post("/monitored-models/", json=monitored_model)
+    assert response.status_code == 201
+    assert response.json()["model_name"] == monitored_model["model_name"]
+    assert response.json()["model_description"] == monitored_model["model_description"]
+    assert response.json()["model_status"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_model_name_unique(client: AsyncClient):
+    """
+    Test create monitored model with model name that already exists.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    iteration = {
+        "iteration_name": "Test iteration",
+        "experiment_name": "Test experiment",
+        "project_title": "Test project",
+        "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "user_name": "Test user"
+    }
+
+    monitored_model = {
+        "model_name": "Test monitored model",
+        "model_description": "Test monitored model description",
+        "iteration": iteration
+    }
+
+    response = await client.post("/monitored-models/", json=monitored_model)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Monitored model name already exists."
+
+
+@pytest.mark.asyncio
+async def test_get_monitored_model_by_id(client: AsyncClient):
+    """
+    Test get monitored model by id.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    iteration = {
+        "iteration_name": "Test iteration",
+        "experiment_name": "Test experiment",
+        "project_title": "Test project",
+        "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "user_name": "Test user"
+    }
+
+    monitored_model = {
+        "model_name": "Test monitored model 2",
+        "model_description": "Test monitored model description",
+        "model_status": "active",
+        "iteration": iteration
+    }
+
+    response = await client.post("/monitored-models/", json=monitored_model)
+    monitored_model_id = response.json()["_id"]
+    response = await client.get(f"/monitored-models/id/{monitored_model_id}")
+    assert response.status_code == 200
+    assert response.json()["model_name"] == monitored_model["model_name"]
+
+
+@pytest.mark.asyncio
+async def test_get_monitored_model_by_name(client: AsyncClient):
+    """
+    Test get monitored model by name.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    iteration = {
+        "iteration_name": "Test iteration",
+        "experiment_name": "Test experiment",
+        "project_title": "Test project",
+        "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "user_name": "Test user"
+    }
+
+    monitored_model = {
+        "model_name": "Test monitored model 3",
+        "model_description": "Test monitored model description",
+        "model_status": "archived",
+        "iteration": iteration
+    }
+
+    response = await client.post("/monitored-models/", json=monitored_model)
+    monitored_model_name = response.json()["model_name"]
+    response = await client.get(f"/monitored-models/name/{monitored_model_name}")
+    assert response.status_code == 200
+    assert response.json()["model_name"] == monitored_model["model_name"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_monitored_models(client: AsyncClient):
+    """
+    Test get all monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    response = await client.get("/monitored-models/")
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_archived_monitored_models(client: AsyncClient):
+    """
+    Test get archived monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    response = await client.get("/monitored-models/archived")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_active_monitored_models(client: AsyncClient):
+    """
+    Test get active monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    response = await client.get("/monitored-models/active")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_idle_monitored_models(client: AsyncClient):
+    """
+    Test get idle monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    response = await client.get("/monitored-models/idle")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_non_archived_monitored_models(client: AsyncClient):
+    """
+    Test get non-archived monitored models.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    response = await client.get("/monitored-models/non-archived")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_update_monitored_model(client: AsyncClient):
+    """
+    Test update monitored model.
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    iteration = {
+        "iteration_name": "Test iteration",
+        "experiment_name": "Test experiment",
+        "project_title": "Test project",
+        "experiment_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "project_id": "5f9b3b7e9c9d6c0a3c7b3b7e",
+        "user_name": "Test user"
+    }
+
+    monitored_model = {
+        "model_name": "Test monitored model 5",
+        "model_description": "Test monitored model description",
+        "model_status": "idle"
+    }
+
+    monitored_model_changed = {
+        "model_name": "Test monitored model 4 changed",
+        "model_description": "Test monitored model description changed",
+        "model_status": "active",
+        "iteration": iteration
+    }
+
+    response = await client.post("/monitored-models/", json=monitored_model)
+    monitored_model_id = response.json()["_id"]
+    monitored_model["model_name"] = "Test monitored model 5"
+    response = await client.put(f"/monitored-models/{monitored_model_id}", json=monitored_model_changed)
+    assert response.status_code == 200
+    assert response.json()["model_name"] == monitored_model_changed["model_name"]
+    assert response.json()["model_status"] == monitored_model_changed["model_status"]


### PR DESCRIPTION
1. Created MonitoredModel:
   - model_name: str
   - model_description: Optional[str]
   - model_status: str 
   - iteration: Optional[Iteration]

2. Created routers:
   - get_all_monitored_models()
   - get_non_archived_monitored_models()
   - get_archived_monitored_models()
   - get_active_monitored_models()
   - get_idle_monitored_models()
   - get_monitored_model_by_name(name: str)
   - get_monitored_model_by_id(id: PydanticObjectId)
   - create_monitored_model(monitored_model: MonitoredModel)
   - update_monitored_model(id: PydanticObjectId, monitored_model: MonitoredModel)
   - delete_monitored_model(id: PydanticObjectId)

Restrictions: 
   - There is a restriction on the model_name which must be unique
   - model_status must be one of these three: active, idle, archived

Added checking iteration existing and model_status in create and update routers

model_name parameter was deleted from Iteration class. Requires checking library test files!