### PR TITLE
[MLOPS-225] Added saving predictions data to database

### DIFF
--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -19,14 +19,13 @@ class MonitoredModel(Document):
     - **iteration (Iteration)**: Related Iteration.
     - **ml_model (object)**: ML model. ---- TODO: add coded pkl file
     """
-
     model_name: str = Field(description="Model name", min_length=1, max_length=100)
     model_description: Optional[str] = Field(default="", description="Model description", max_length=150)
     model_status: str = Field(default='idle', description="Model status")
     iteration: Optional[Iteration] = Field(default=None, description="Iteration")
     pinned: bool = Field(default=False, description="Model pinned status")
+    predictions_data: Optional[list] = Field(default=[], description="Predictions data")
     # ml_model: Optional[object] = Field(default=None, description="Loaded ml model")
-
 
     @validator('model_status')
     def validate_status(cls, v):
@@ -77,7 +76,8 @@ class MonitoredModel(Document):
                         }
                     ]
                 },
-                "pinned": False
+                "pinned": False,
+                "predictions_data": []
             }
         }
 
@@ -92,11 +92,12 @@ class UpdateMonitoredModel(MonitoredModel):
     - **model_status (str)**: Monitored model status.
     - **iteration (Iteration)**: Related Iteration.
     """
-
     model_name: Optional[str]
     model_description: Optional[str]
     model_status: Optional[str]
     iteration: Optional[Iteration]
+    pinned: Optional[bool]
+    predictions_data: Optional[list]
 
     class Config:
         schema_extra = {
@@ -120,6 +121,7 @@ class UpdateMonitoredModel(MonitoredModel):
                         }
                     ]
                 },
-                "pinned": False
+                "pinned": False,
+                "predictions_data": []
             }
         }

--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -17,6 +17,8 @@ class MonitoredModel(Document):
     - **model_description (str)**: Monitored model description.
     - **model_status (str)**: Monitored model status.
     - **iteration (Iteration)**: Related Iteration.
+    - **pinned (bool)**: Monitored model pinned status.
+    - **predictions_data (list[dict])**: Predictions data list of rows as dicts.
     - **ml_model (object)**: ML model. ---- TODO: add coded pkl file
     """
     model_name: str = Field(description="Model name", min_length=1, max_length=100)
@@ -24,7 +26,7 @@ class MonitoredModel(Document):
     model_status: str = Field(default='idle', description="Model status")
     iteration: Optional[Iteration] = Field(default=None, description="Iteration")
     pinned: bool = Field(default=False, description="Model pinned status")
-    predictions_data: Optional[list] = Field(default=[], description="Predictions data")
+    predictions_data: Optional[list[dict]] = Field(default=[], description="Predictions data")
     # ml_model: Optional[object] = Field(default=None, description="Loaded ml model")
 
     @validator('model_status')
@@ -91,13 +93,15 @@ class UpdateMonitoredModel(MonitoredModel):
     - **model_description (str)**: Monitored model description.
     - **model_status (str)**: Monitored model status.
     - **iteration (Iteration)**: Related Iteration.
+    - **pinned (bool)**: Monitored model pinned status.
+    - **predictions_data (list[dict])**: Predictions data list of rows as dicts.
     """
     model_name: Optional[str]
     model_description: Optional[str]
     model_status: Optional[str]
     iteration: Optional[Iteration]
     pinned: Optional[bool]
-    predictions_data: Optional[list]
+    predictions_data: Optional[list[dict]]
 
     class Config:
         schema_extra = {

--- a/back-end/app/routers/monitored_model.py
+++ b/back-end/app/routers/monitored_model.py
@@ -315,10 +315,16 @@ async def monitored_model_predict(id: PydanticObjectId, data: dict) -> dict:
 
     try:
         prediction = ml_model.predict(pd.DataFrame([data]))[0]
+        monitored_model.predictions_data.append({
+            **data,
+            'prediction': prediction
+        })
+        await monitored_model.save()
     except Exception as e:
         raise monitored_model_prediction_exception(str(e))
 
     return {
+        **data,
         'prediction': prediction
     }
 

--- a/back-end/app/tests/routers/test_monitored_model.py
+++ b/back-end/app/tests/routers/test_monitored_model.py
@@ -685,11 +685,14 @@ async def test_update_monitored_model_with_changing_iteration(client: AsyncClien
 
     response = await client.post("/monitored-models/", json=monitored_model)
     monitored_model_id = response.json()["_id"]
+    monitored_model_name = response.json()["model_name"]
 
     monitored_model_changed_v1 = {
         "model_status": "active",
         "iteration": old_iteration_to_model
     }
+
+    monitored_model_response = await client.put(f"/monitored-models/{monitored_model_id}", json=monitored_model_changed_v1)
 
     new_iteration = {
         "iteration_name": "Iteration 5",

--- a/back-end/app/tests/routers/test_monitored_model.py
+++ b/back-end/app/tests/routers/test_monitored_model.py
@@ -157,9 +157,6 @@ async def test_get_monitored_model_by_id(client: AsyncClient):
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
-    iteration_id = response.json()["id"]
-
-    iteration_to_model = response.json()
 
     monitored_model = {
         "model_name": "Engine failure prediction model v2",
@@ -341,7 +338,6 @@ async def test_update_monitored_model_with_iteration(client: AsyncClient):
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
-    iteration_id = response.json()["id"]
 
     iteration_to_model = response.json()
 
@@ -396,7 +392,6 @@ async def test_update_iteration_with_no_path_to_model(client: AsyncClient):
     }
 
     response = await client.post(f"/projects/{project_id}/experiments/{experiment_id}/iterations/", json=iteration)
-    iteration_id = response.json()["id"]
 
     iteration_to_model = response.json()
     
@@ -465,12 +460,19 @@ async def test_monitored_ml_model_predict_success(client: AsyncClient):
     response = await client.post(f"/monitored-models/{monitored_model_id}/predict", json=data)
     assert response.status_code == 200
     assert response.json()["prediction"] == pytest.approx(7.89043535267264)
+    assert response.json()["X1"] == 1.0
+
+    # check monitored model predictions data after prediction
+    monitored_model_name = "Engine failure prediction model v4 changed"
+    response = await client.get(f"/monitored-models/name/{monitored_model_name}")
+    assert response.status_code == 200
+    assert len(response.json()["predictions_data"]) == 1
 
 
 @pytest.mark.asyncio
 async def test_monitored_ml_model_predict_failure(client: AsyncClient):
     """
-    Test monitored model predict with failure.
+    Test monitored model predict with failure (additional column not seen during fit).
 
     Args:
         client (AsyncClient): Async client fixture
@@ -484,14 +486,55 @@ async def test_monitored_ml_model_predict_failure(client: AsyncClient):
 
     monitored_model_id = response.json()["_id"]
     data = {
-        "X1": 1.0,
-        "X2": 2.0,
+        "X1": 21.0,
+        "X2": 37.0,
         "X3": 3.0
     }
     response = await client.post(f"/monitored-models/{monitored_model_id}/predict", json=data)
     assert response.status_code == 400
     assert response.json()["detail"] == "Cannot make prediction: The feature names should match those " \
                                         "that were passed during fit.\nFeature names unseen at fit time:\n- X3\n"
+
+    # check monitored model predictions data after prediction (only one previous prediction)
+    monitored_model_name = "Engine failure prediction model v4 changed"
+    response = await client.get(f"/monitored-models/name/{monitored_model_name}")
+    assert response.status_code == 200
+    assert len(response.json()["predictions_data"]) == 1
+    assert response.json()["predictions_data"][0]["prediction"] == pytest.approx(7.89043535267264)
+
+
+@pytest.mark.asyncio
+async def test_monitored_ml_model_predict_failure_2(client: AsyncClient):
+    """
+    Test monitored model predict with failure (invalid input column type).
+
+    Args:
+        client (AsyncClient): Async client fixture
+
+    Returns:
+        None
+    """
+    monitored_model_name = "Engine failure prediction model v4 changed"
+    response = await client.get(f"/monitored-models/name/{monitored_model_name}")
+    assert response.status_code == 200
+
+    monitored_model_id = response.json()["_id"]
+    data = {
+        "X1": 100.0,
+        "X2": "Invalid value :)",
+    }
+    response = await client.post(f"/monitored-models/{monitored_model_id}/predict", json=data)
+    print(response.json())
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cannot make prediction: could not convert" \
+                                        " string to float: 'Invalid value :)'"
+
+    # check monitored model predictions data after prediction (only one previous prediction)
+    monitored_model_name = "Engine failure prediction model v4 changed"
+    response = await client.get(f"/monitored-models/name/{monitored_model_name}")
+    assert response.status_code == 200
+    assert len(response.json()["predictions_data"]) == 1
+    assert response.json()["predictions_data"][0]["prediction"] == pytest.approx(7.89043535267264)
 
 
 @pytest.mark.asyncio
@@ -642,14 +685,11 @@ async def test_update_monitored_model_with_changing_iteration(client: AsyncClien
 
     response = await client.post("/monitored-models/", json=monitored_model)
     monitored_model_id = response.json()["_id"]
-    monitored_model_name = response.json()["model_name"]
 
     monitored_model_changed_v1 = {
         "model_status": "active",
         "iteration": old_iteration_to_model
     }
-
-    monitored_model_response = await client.put(f"/monitored-models/{monitored_model_id}", json=monitored_model_changed_v1)
 
     new_iteration = {
         "iteration_name": "Iteration 5",


### PR DESCRIPTION
Predictions along with input data are now stored in database. 
Added predictions_data: list[dict] attribute to MonitoredModel class which stores it as:
```
[
    { **input_data, 'prediction': ... },
    { **input_data, 'prediction': ... },
    ...
]
```