### PR TITLE
[MLOPS-235-236] Added model for PredictionData and updated monitored model prediction router 

### DIFF
--- a/back-end/app/models/monitored_model.py
+++ b/back-end/app/models/monitored_model.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, status
 from datetime import datetime
 
 from app.models.iteration import Iteration
+from app.models.prediction_data import PredictionData
 
 
 class MonitoredModel(Document):
@@ -31,7 +32,7 @@ class MonitoredModel(Document):
     model_status: str = Field(default='idle', description="Model status")
     iteration: Optional[Iteration] = Field(default=None, description="Iteration")
     pinned: bool = Field(default=False, description="Model pinned status")
-    predictions_data: Optional[list[dict]] = Field(default=[], description="Predictions data")
+    predictions_data: Optional[list[PredictionData]] = Field(default=[], description="Predictions data")
     ml_model: Optional[str] = Field(default=None, description="Loaded ml model")
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
@@ -109,7 +110,7 @@ class UpdateMonitoredModel(MonitoredModel):
     model_status: Optional[str]
     iteration: Optional[Iteration]
     pinned: Optional[bool]
-    predictions_data: Optional[list[dict]]
+    predictions_data: Optional[list[PredictionData]]
     updated_at: datetime = Field(default_factory=datetime.now)
 
     class Config:

--- a/back-end/app/models/prediction_data.py
+++ b/back-end/app/models/prediction_data.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Union
+from beanie import PydanticObjectId
+from pydantic import BaseModel, Field
+
+
+class PredictionData(BaseModel):
+    """
+    Prediction data model.
+
+    Attributes:
+    - **prediction_date (datetime)**: Prediction date.
+    - **input_data (dict)**: Input data.
+    - **prediction (Union[float, int])**: Prediction.
+    """
+    id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
+    prediction_date: datetime = Field(default_factory=datetime.now)
+    input_data: dict
+    prediction: Union[float, int]
+
+    def __repr__(self) -> str:
+        return f"<PredictionData {self.prediction_date} {self.input_data} {self.prediction}>"
+
+    def __str__(self) -> str:
+        return f"{self.prediction_date} {self.input_data} {self.prediction}"
+
+    def __hash__(self) -> int:
+        return hash(self.prediction_date)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, PredictionData):
+            return self.id == other.id
+        return False
+
+    class Settings:
+        name = "PredictionData"


### PR DESCRIPTION
Created separate model for PredictionData with attributes:
- `id: PydanticObjectId`
- `prediction_date: datetime`
- `input_data: dict`
- `prediction: Union[float, int]`


Integrated monitored model prediction router with new PredictionData model and multiple samples prediction at once.
Now prediction router receives `data: list[dict]` as an input and returns `list[PredictionData]`
Updated & added some new unit tests as well.