### PR TITLE
[MLOPS-245] Added protection against one iteration for 2 monitored models

### DIFF
--- a/back-end/.env
+++ b/back-end/.env
@@ -1,4 +1,4 @@
 MONGODB_URL=mongodb://localhost:27017/
 MONGODB_DB_NAME=mlops
-TESTING=True
+TESTING=False
 MONGODB_TEST_DB_NAME=mlops_test

--- a/back-end/.env
+++ b/back-end/.env
@@ -1,4 +1,4 @@
 MONGODB_URL=mongodb://localhost:27017/
 MONGODB_DB_NAME=mlops
-TESTING=False
+TESTING=True
 MONGODB_TEST_DB_NAME=mlops_test

--- a/back-end/app/routers/exceptions/monitored_model.py
+++ b/back-end/app/routers/exceptions/monitored_model.py
@@ -69,3 +69,17 @@ def monitored_model_decoding_pkl_file_exception(description: str):
         status_code=status.HTTP_400_BAD_REQUEST,
         detail=f"Cannot decode pkl file: {description}"
     )
+
+
+def monitored_model_has_no_iteration_to_check_exception():
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Monitored model has no iteration."
+    )
+
+
+def iteration_is_assigned_to_monitored_model_exception():
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Iteration is assigned to monitored model."
+    )


### PR DESCRIPTION
Now you are not able to create second monitored model to assigned iteration to existing monitored model.

Unit test done