### PR TITLE
[MLOPS-257] Added actual parameter to PredictionData and routers

### DIFF
--- a/server/app/models/monitored_model.py
+++ b/server/app/models/monitored_model.py
@@ -26,6 +26,7 @@ class MonitoredModel(Document):
     - **predictions_data (list[dict])**: Predictions data list of rows as dicts.
     - **ml_model (str)**: ML model
     - **interactive_charts (list[MonitoredModelInteractiveChart])**: Interactive charts
+    - **interactive_charts_existed (set[tuple[str, Optional[str], Optional[str]]])**: Interactive charts existed pairs of columns
     - **created_at (datetime)**: Monitored model creation date.
     - **updated_at (datetime)**: Monitored model last update date.
     """

--- a/server/app/models/monitored_model_chart.py
+++ b/server/app/models/monitored_model_chart.py
@@ -7,6 +7,15 @@ from fastapi import HTTPException, status
 class MonitoredModelInteractiveChart(BaseModel):
     """
     Interactive chart model for monitored models.
+
+    Attributes:
+    - **id (PydanticObjectId)**: Interactive chart id.
+    - **monitored_model_id (PydanticObjectId)**: Monitored model id.
+    - **chart_type (str)**: Chart type.
+    - **first_column (str)**: First column name.
+    - **second_column (Optional[str])**: Second column name.
+    - **bin_method (Optional[str])**: Bin method.
+    - **bin_number (Optional[int])**: Bin number.
     """
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     monitored_model_id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="monitored_model_id")

--- a/server/app/models/prediction_data.py
+++ b/server/app/models/prediction_data.py
@@ -12,11 +12,13 @@ class PredictionData(BaseModel):
     - **prediction_date (datetime)**: Prediction date.
     - **input_data (dict)**: Input data.
     - **prediction (Union[float, int])**: Prediction.
+    - **actual (Union[float, int])**: Actual.
     """
     id: PydanticObjectId = Field(default_factory=PydanticObjectId, alias="id")
     prediction_date: datetime = Field(default_factory=datetime.now)
     input_data: dict
     prediction: Union[float, int]
+    actual: Union[float, int] = Field(default=None)
 
     def __repr__(self) -> str:
         return f"<PredictionData {self.prediction_date} {self.input_data} {self.prediction}>"
@@ -34,3 +36,21 @@ class PredictionData(BaseModel):
 
     class Settings:
         name = "PredictionData"
+
+
+class UpdatePredictionData(BaseModel):
+    """
+    Update prediction data model.
+
+    Attributes:
+    - **actual (Union[float, int])**: actual prediction value.
+    """
+
+    actual: Union[float, int] = Field(default=None)
+
+    class Config:
+        schema_extra = {
+                    "example": {
+                        "actual": 0.5
+                    }
+                }

--- a/server/app/routers/exceptions/monitored_model.py
+++ b/server/app/routers/exceptions/monitored_model.py
@@ -160,3 +160,10 @@ def monitored_model_chart_changing_columns_exception():
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="Cannot change columns for existing chart."
     )
+
+
+def monitored_model_prediction_not_found_exception():
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Monitored model prediction with such id not found."
+    )


### PR DESCRIPTION
Based on requirements 'actual' parameter has been added to PredictionData. Now user is able to set this parameter for selected prediction.

PUT and DELETE routers added for that

Tested